### PR TITLE
Fix superlinter parse error from config deprecation

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -43,7 +43,7 @@ jobs:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: dist/**/*
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TYPESCRIPT_DEFAULT_STYLE: prettier
+          VALIDATE_TYPESCRIPT_PRETTIER: true
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_JSCPD: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -43,7 +43,7 @@ jobs:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: dist/**/*
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_TYPESCRIPT_PRETTIER: true
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_JSCPD: false
+          VALIDATE_TYPESCRIPT_STANDARD: false


### PR DESCRIPTION
This error was as a result of a configuration flag deprecation, documented here: https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md#javascript_default_style-and-typescript_default_style

Because were using the floating `@6` version tag, this broke without an explicit upgrade from us.

This also mirrors changes in the repo this is a template of: https://github.com/actions/typescript-action/commit/c35fc0b8c9d14d129b204263c10e5f131159a9e4