### PR TITLE
Upgrade Node.js version from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ inputs:
     required: true
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
Based on the deprecation notice https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/