### PR TITLE
Bump to 0.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setup-pkl",
   "description": "GitHub Action for installing Pkl",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "author": "The Pkl Community",
   "private": true,
   "repository": {


### PR DESCRIPTION
Bumps the version to `0.0.9` so a release can be cut that includes the Node.js 20→24 upgrade from #74 (merged, but not yet released — the latest release `v0.0.8` predates that change).

After this merges, the release is cut from `main` via `script/release` (enter `v0.0.9`), which tags `v0.0.9` and moves the floating `v0` tag onto it.

No `dist/` rebuild needed — #74 only touched `action.yml`, so the bundle is unchanged.

Requested in #74: https://github.com/pkl-community/setup-pkl/pull/74#issuecomment-4776616868

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QchHEfSxiKoAWyFp1opMNM)_