### PR TITLE
Fix README status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # `setup-pkl` GitHub Action
 
-[![GitHub Super-Linter](https://github.com/actions/typescript-action/actions/workflows/linter.yml/badge.svg)](https://github.com/super-linter/super-linter)
-![CI](https://github.com/actions/typescript-action/actions/workflows/ci.yml/badge.svg)
-[![Check dist/](https://github.com/actions/typescript-action/actions/workflows/check-dist.yml/badge.svg)](https://github.com/actions/typescript-action/actions/workflows/check-dist.yml)
+[![GitHub Super-Linter](https://github.com/pkl-community/setup-pkl/actions/workflows/lint.generated.yml/badge.svg)](https://github.com/pkl-community/setup-pkl/actions/workflows/lint.generated.yml)
+[![CI](https://github.com/pkl-community/setup-pkl/actions/workflows/test.generated.yml/badge.svg)](https://github.com/pkl-community/setup-pkl/actions/workflows/test.generated.yml)
+[![Check dist/](https://github.com/pkl-community/setup-pkl/actions/workflows/check-dist.generated.yml/badge.svg)](https://github.com/pkl-community/setup-pkl/actions/workflows/check-dist.generated.yml)
 [![Coverage](./badges/coverage.svg)](./badges/coverage.svg)
 
 > [!CAUTION]


### PR DESCRIPTION
## What
The three status badges at the top of the README still pointed at the upstream template repo (`actions/typescript-action`) and at workflow filenames that don't exist in this repo (`linter.yml`, `ci.yml`, `check-dist.yml`), so they rendered as broken / "unknown".

Repointed all three to `pkl-community/setup-pkl` and the actual generated workflow files:

| Badge | Now points to |
|-------|---------------|
| Super-Linter | `lint.generated.yml` |
| CI | `test.generated.yml` |
| Check dist/ | `check-dist.generated.yml` |

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFAXqJXsmtgj2pPzrpqXzm)_