### PR TITLE
Bump pkl version 0.28.2 → 0.31.1

### DIFF
--- a/.github/pkl-workflows/check-actions.pkl
+++ b/.github/pkl-workflows/check-actions.pkl
@@ -4,7 +4,7 @@ import "modules/Steps.pkl"
 name = "Check Pkl Actions Converted"
 
 env {
-  ["TEST_PKL_VERSION"] = "0.28.2"
+  ["TEST_PKL_VERSION"] = "0.31.1"
 }
 
 on {

--- a/.github/pkl-workflows/check-dist.pkl
+++ b/.github/pkl-workflows/check-dist.pkl
@@ -13,7 +13,7 @@ import "modules/Steps.pkl"
 name = "Check Transpiled JavaScript"
 
 env {
-  ["TEST_PKL_VERSION"] = "0.28.2"
+  ["TEST_PKL_VERSION"] = "0.31.1"
 }
 
 on {

--- a/.github/pkl-workflows/test.pkl
+++ b/.github/pkl-workflows/test.pkl
@@ -4,7 +4,7 @@ import "modules/Steps.pkl"
 name = "Run tests"
 
 env {
-  ["TEST_PKL_VERSION"] = "0.28.2"
+  ["TEST_PKL_VERSION"] = "0.31.1"
 }
 
 on {

--- a/.github/workflows/check-actions.generated.yml
+++ b/.github/workflows/check-actions.generated.yml
@@ -8,7 +8,7 @@ name: Check Pkl Actions Converted
     branches:
     - main
 env:
-  TEST_PKL_VERSION: 0.28.2
+  TEST_PKL_VERSION: 0.31.1
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/check-dist.generated.yml
+++ b/.github/workflows/check-dist.generated.yml
@@ -8,7 +8,7 @@ name: Check Transpiled JavaScript
     branches:
     - main
 env:
-  TEST_PKL_VERSION: 0.28.2
+  TEST_PKL_VERSION: 0.31.1
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/test.generated.yml
+++ b/.github/workflows/test.generated.yml
@@ -8,7 +8,7 @@ name: Run tests
     branches:
     - main
 env:
-  TEST_PKL_VERSION: 0.28.2
+  TEST_PKL_VERSION: 0.31.1
 permissions:
   contents: read
 jobs:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ steps:
   - name: Install pkl
     uses: pkl-community/setup-pkl@v0
     with:
-      pkl-version: 0.28.2
+      pkl-version: 0.31.1
 ```
 
 ### Options


### PR DESCRIPTION
## What
Updates the pinned Pkl version from `0.28.2` to the current latest release **0.31.1**:

- `README.md` usage example
- `TEST_PKL_VERSION` in the three Pkl workflow sources (`test.pkl`, `check-dist.pkl`, `check-actions.pkl`) and their generated YAML

Both the `.pkl` sources and the generated `*.generated.yml` are updated together so the `check-actions` workflow (which regenerates and runs `git diff --exit-code`) stays green.

## Note on generation
`pkl-gha`'s package registry (`pkg.pkl-lang.org`) isn't reachable from this environment, so the generated YAML was updated by hand. The change is limited to the `TEST_PKL_VERSION` leaf value, so it's identical to what `npm run gen:actions` produces — and the `check-actions` CI job verifies exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFAXqJXsmtgj2pPzrpqXzm)_